### PR TITLE
Remove docker image after exiting session

### DIFF
--- a/scripts/launch-container-linux.sh
+++ b/scripts/launch-container-linux.sh
@@ -2,7 +2,7 @@
 
 xhost +
 
-docker run -it \
+docker run --rm -it \
     -e DISPLAY=$DISPLAY \
     -v /tmp/.X11-unix:/tmp/.X11-unix \
     --name lsdslam_noros \

--- a/scripts/launch-container-mac.sh
+++ b/scripts/launch-container-mac.sh
@@ -14,7 +14,7 @@ echo display number = $display_number
 xhost + $ip
 
 # --privileged for debugging
-docker run -it \
+docker run --rm -it \
     -e DISPLAY=$ip$display_number \
     -e QT_X11_NO_MITSHM=1 \
     --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \


### PR DESCRIPTION
Without this, if I launch a docker container and exit it, I can no longer re-run the launch script. I have to first kill the container.