### PR TITLE
Fix: Failed to load module "canberra-gtk-module"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ RUN git clone https://github.com/RainerKuemmerle/g2o.git \
 WORKDIR $WORKSPACE
 
 RUN apt-get update
-RUN apt-get -y install libboost-all-dev freeglut3-dev libglew-dev
+RUN apt-get -y install libboost-all-dev freeglut3-dev libglew-dev libcanberra-gtk-module
 
 # build in a single process since it seems parallel build doesn't contribute to the speed
 RUN git clone https://github.com/IshitaTakeshi/lsd_slam_noros.git \


### PR DESCRIPTION
Fixes the following error message:
```
Doing Random initialization!

(DebugWindow DEPTH:18): Gtk-WARNING **: 06:31:57.443: gtk_disable_setlocale() must be called before gtk_init()
Gtk-Message: 06:31:57.445: Failed to load module "canberra-gtk-module"
Gtk-Message: 06:31:57.453: Failed to load module "canberra-gtk-module"
Segmentation fault (core dumped)
```